### PR TITLE
Fix: En el modelo de usuarios, a la hora de editar cuando el usuario …

### DIFF
--- a/modelo/usuarios_modelo.php
+++ b/modelo/usuarios_modelo.php
@@ -191,7 +191,9 @@ class UsuariosModelo extends ConexionBD {
                 move_uploaded_file($this->foto['tmp_name'],"fotosEmpleados/$newFileName");
             }else if(($this->foto['error'] == 4) && ($idUsuarioSeleccionado != $this->documento)) {
                 /* el usuario NO cambio la foto pero si modifico el id */
-                rename("fotosEmpleados/$oldFileName","fotosEmpleados/$newFileName");
+                if(file_exists($oldFileName)) {
+                    rename("fotosEmpleados/$oldFileName","fotosEmpleados/$newFileName");
+                }
             }
 
             $this->result["complete"] = true;


### PR DESCRIPTION
…No cambio la foto pero si modifico el id, agregue una validacion, ya que si previamente no hay una imagen cargada, no va a ser necesario renombrar una foto que no existe