### PR TITLE
Fix: arregle el error de que cada vez que le modificaba el documento …

### DIFF
--- a/controlador/usuarios_controlador.php
+++ b/controlador/usuarios_controlador.php
@@ -114,7 +114,7 @@ class UsuariosControlador extends Controlador{
             $this->result = $this->instanciaModelo->editar(htmlentities(addslashes($idUsuarioSeleccionado)));
             
             if($this->result["complete"]) {
-                if($_SESSION["usuario"]["documento"] == $this->instanciaModelo->getDocumento()) {
+                if($_SESSION["usuario"]["documento"] == $idUsuarioSeleccionado || $_SESSION["usuario"]["documento"] == $this->instanciaModelo->getDocumento()) {
                     $_SESSION["usuario"]["documento"] = $this->instanciaModelo->getDocumento();
                     $_SESSION["usuario"]["nombre"] = $this->instanciaModelo->getNombre();
                     $_SESSION["usuario"]["apellido"] = $this->instanciaModelo->getApellido();


### PR DESCRIPTION
…al usuario nos arrojaba al login, pero el problema estaba en que no se estaba modificando la sesion, por lo tanto agregue otra validacion para que tambien verifique que el documento de la sesion sea igual a el documento o idUsuarioSeleccionado para que modifique la info necesaria de la sesion